### PR TITLE
[perl] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/perl.changes
+++ b/perl.changes
@@ -1,3 +1,6 @@
+* Thu Aug 19 2021 Björn Bidar <bjorn.bidar@jolla.com> - 5.16.3-4
+- [perl] Explicitly depend on pkgconfig(libcrypt). JB#54931
+
 * Wed Aug 18 2021 Björn Bidar <bjorn.bidar@jolla.com> - 5.16.3-3
 - Fix search libpath for 64bit arches. JB#54767 
 
@@ -71,4 +74,3 @@
 
 * Sun Nov 02 2008 Anas Nashif <anas.nashif@intel.com> 5.10.0
 - New version from fc10
-

--- a/perl.spec
+++ b/perl.spec
@@ -25,7 +25,7 @@
 
 Name:           perl
 Version:        %{perl_version}
-Release:        3
+Release:        4
 Epoch:          %{perl_epoch}
 Summary:        Practical Extraction and Report Language
 Group:          Development/Languages
@@ -91,7 +91,9 @@ Patch15:        errno3-lib-h2ph.t-to-test-generated-t-_h2ph_pre.ph.patch
 # Update some of the bundled modules
 # see http://fedoraproject.org/wiki/Perl/perl.spec for instructions
 
-BuildRequires:  db4-devel, zlib-devel, bzip2-devel
+BuildRequires: db4-devel, bzip2-devel
+BuildRequires: pkgconfig(zlib)
+BuildRequires: pkgconfig(libcrypt))
 %if %{with gdbm}
 BuildRequires: gdbm-devel
 %endif


### PR DESCRIPTION
perl depends on pkconfig(libcrypt) for the crypt function but it was
not included. This makes the build fail when pkconfig(libcrypt) is not bundled in the glib-devel package.